### PR TITLE
using if_any() instead of across()

### DIFF
--- a/R/expect-unique.R
+++ b/R/expect-unique.R
@@ -80,7 +80,7 @@ expect_unique <- function(vars,
     mutate(count = n()) %>%
     ungroup() %>%
     select({{ vars }}, count) %>%
-    filter(across(-count, ~ !.x %in% exclude))
+    filter(if_any(-count, ~ !.x %in% exclude))
 
   act$result <- act$result_data$count == 1
 


### PR DESCRIPTION
We're in the process of releasing `dplyr` 1.0.8, which unfortunately causes the released version of `testdat` to fail, with: 

````
── After ─────────────────────────────────────────────────────────────────────────────────────────────────────
> checking tests ... ERROR
  See below...

── Test failures ─────────────────────────────────────────────────────────────────────────────── testthat ────

> library(testthat)
> library(testdat)

Attaching package: 'testdat'

The following object is masked from 'package:testthat':

    matches

> 
> test_check("testdat")
══ Failed tests ════════════════════════════════════════════════════════════════
── Failure (test-reporter_excel.R:8:3): excel_results ──────────────────────────
Expectation did not succeed:
x_summ[x_summ$test == "passes", ] has 1 records failing value check on variable `status`.
Filter: None
Arguments: `"success", miss = <chr: NA, "">`
── Failure (test-reporter_excel.R:44:3): excel_results ─────────────────────────
`x_xl_summary` not equal to `xl_summary`.
Component "tests": Mean relative difference: 0.25
Component "warning": Mean relative difference: 1
── Failure (test-reporter_excel.R:47:3): excel_results ─────────────────────────
nrow(x_xl_passing) not equal to 0.
1/1 mismatches
[1] 1 - 0 == 1

[ FAIL 3 | WARN 27 | SKIP 0 | PASS 165 ]
Error: Test failures
Execution halted

1 error x | 0 warnings ✓ | 0 notes ✓
````

I'm not seeing the same problem with the dev version, however it's getting a warning about the use of `across()` inside `filter()` which is getting deprecated in favor of either `if_any()` or `if_all()`.